### PR TITLE
Fixed windriver: Safe cross threaded operation and Post-build for Rel…

### DIFF
--- a/code/windows/PhoneVR/PhoneVR/PhoneVR.vcxproj
+++ b/code/windows/PhoneVR/PhoneVR/PhoneVR.vcxproj
@@ -157,6 +157,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\libs\x264\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(SolutionDir)$(Configuration)\$(Platform)" "C:\Program Files\PhoneVR\PVRServer\bin\win64" /h /i /c /k /e /r /y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\common\src\PVRGlobals.cpp" />


### PR DESCRIPTION
…ease build

1. Added Post build script for Windows driver Release|x64 to copy the output files automatically to `C:\Program Files\PhoneVR\PVRServer\bin\win64`

2. Added Mutex to quatQueue which is being used as cross-thread buffer without locking(un-safe). #L232 often return `deque iterator not dereferenceable` error runtime. This commit fixes it.