### PR TITLE
[Bug] SteamVR Headset Detection Issue Fix

### DIFF
--- a/code/common/src/Utils/ThreadUtils.h
+++ b/code/common/src/Utils/ThreadUtils.h
@@ -134,7 +134,10 @@ class RefWhistle
 	std::mutex mtx;
 
 public:
-	RefWhistle(std::chrono::microseconds loopTime) : lt(loopTime) {}
+	RefWhistle(std::chrono::microseconds loopTime) : lt(loopTime) {
+        tp = Clk::now();
+        pert = std::chrono::microseconds::zero();
+	}
 
 	void wait()
 	{


### PR DESCRIPTION
Issue: SteamVR was not able detect PhoneVR Android device as headset.

Problem was PhoneVR Android app was not able to send Android Acceleration Sensor Data through [PVRStartSensorData()](https://github.com/ShootingKing-AM/PhoneVR/blob/master/code/mobile/mobile-common/PVRSockets.cpp#L121)  which was getting hold by [ref.wait()](https://github.com/ShootingKing-AM/PhoneVR/blob/master/code/mobile/mobile-common/PVRSockets.cpp#L140)

This issue was not obseved in Debug build of app, only occuring on Release build. [Variables](https://github.com/ShootingKing-AM/PhoneVR/blob/master/code/common/src/Utils/ThreadUtils.h#L131-L134) were not initialized in Release build, resulting in infinite wait.

Related issues: #24, #26