### PR TITLE
[FIX] Logs - Logging

### DIFF
--- a/code/common/src/PVRGlobals.cpp
+++ b/code/common/src/PVRGlobals.cpp
@@ -29,8 +29,8 @@ namespace
 	int64_t pvrdebug_oldMs = 0;
 	int64_t pvrInfo_oldMs = 0;
 
-	const wstring logFileDebug = L"\\..\\..\\drivers\\pvr\\logs\\pvrDebuglog.txt";
-	const wstring logFileInfo = L"\\..\\..\\drivers\\pvr\\logs\\pvrlog.txt";
+	const wstring logFileDebug = L"\\..\\..\\drivers\\PVRServer\\logs\\pvrDebuglog.txt";
+	const wstring logFileInfo = L"\\..\\..\\drivers\\PVRServer\\logs\\pvrlog.txt";
 }
 
 std::wstring _GetExePath(void)

--- a/code/windows/PhoneVR/PhoneVR/PVRFileManager.h
+++ b/code/windows/PhoneVR/PhoneVR/PVRFileManager.h
@@ -59,7 +59,7 @@ namespace
 	};
 
 	//const wchar_t *const setsFile = L"C:\\Program Files\\PhoneVR\\pvrsettings.json";
-	const wchar_t *const setsFile = L"\\..\\..\\drivers\\pvr\\pvrsettings.json";
+	const wchar_t *const setsFile = L"\\..\\..\\drivers\\PVRServer\\pvrsettings.json";
 	
 	nlohmann::json PVRGetSets() 
 	{


### PR DESCRIPTION
Logging broke after recent build. Typo in address making the LogFIle as "NotFound"

Many users(#43) reported logs being empty post 0.1build_53 (PR #42 )

This PR fixes the issue.